### PR TITLE
Moved the robot command timeout specification to the robot object cre…

### DIFF
--- a/python/common/robot_drive.py
+++ b/python/common/robot_drive.py
@@ -38,6 +38,7 @@ sending commands.
 
 """
 
+from common.robot_if import *
 from common.scuttle_drive import *
 
 __all__ = ['get_robot_control_instance',
@@ -66,7 +67,7 @@ def get_robot_control_instance(config):
     global _instance_count
 
     if _robot == None:
-        _robot = ScuttleDrive(config)
+        _robot = ScuttleDrive(config, queue_time_out=RobotIf.IN_QUEUE_TIMEOUT)
 
     _instance_count = _instance_count + 1
     return _robot

--- a/python/common/robot_if.py
+++ b/python/common/robot_if.py
@@ -114,7 +114,7 @@ class RobotIf:
         # Process input commands
         while self._stop_thread == False:
             try:
-                cmd = self.inputQ.get(block=True, timeout=RobotIf.IN_QUEUE_TIMEOUT)
+                cmd = self.inputQ.get(block=True, timeout=self._queue_time_out)
                 self.inputQ.task_done()
             except queue.Empty:
                 # Timeout condition

--- a/python/common/scuttle_drive.py
+++ b/python/common/scuttle_drive.py
@@ -46,7 +46,7 @@ class ScuttleDrive(RobotIf):
 
     """
 
-    def __init__(self, config, queue_time_out=RobotIf.IN_QUEUE_TIMEOUT):
+    def __init__(self, config, queue_time_out):
         """
         Args:
             config: str, optional


### PR DESCRIPTION
…ation level.

There is a safety mechanism in the robot motor control thread which
stops the motors if a control command is not received within a specified
timeout value. This timeout value specification is not exposed to the
application level and this fix takes addresses that issue.